### PR TITLE
ReadMe generation wait for hacs to be started

### DIFF
--- a/packages/system/readme_generation.yaml
+++ b/packages/system/readme_generation.yaml
@@ -7,4 +7,22 @@ automation:
       - platform: homeassistant
         event: start
     action:
-      service: readme.generate
+      - wait_for_trigger:
+          - platform: event
+            event_type: hacs/stage
+            event_data:
+              stage: running
+        timeout:
+          minutes: 5
+      - choose:
+          - conditions:
+              - condition: template
+                value_template: "{{ not wait.trigger }}"
+            sequence:
+              # Timeout reached
+              - service: persistent_notification.create
+                data:
+                  title: ReadMe generation failed!
+                  message: Timeout reached! Hacs could not start in time.
+        default:
+          - service: readme.generate


### PR DESCRIPTION
Hi,

I was inspired from you readme generation. Thanks for sharing your config :)
After adding the automation for generating the readme ad startup, I noticed that sometimes hacs could start probably and I got an error in the logs and it happen only when the readme generation is running.
My fix is that I'm waiting for hacs to be started before I generate the readme.

Feel free to change something or also to close it, if you don't want to wait.
Cheers